### PR TITLE
Fix nondeterministic push tests

### DIFF
--- a/cli/dev/get-package-file-paths.ts
+++ b/cli/dev/get-package-file-paths.ts
@@ -17,6 +17,7 @@ export const getPackageFilePaths = (
     cwd: projectDir,
     ignore: ignorePatterns,
   })
+  fileNames.sort()
 
   return fileNames.map((fileName) => path.join(projectDir, fileName))
 }

--- a/tests/cli/push/push5-version-bump.test.ts
+++ b/tests/cli/push/push5-version-bump.test.ts
@@ -31,8 +31,8 @@ test("should bump version if release already exists", async () => {
     "Package created
 
 
-    ⬆︎ snippet.tsx
     ⬆︎ package.json
+    ⬆︎ snippet.tsx
     "@tsci/test-user.test-package@1.0.0" published!
     https://tscircuit.com/test-user/test-package
     "
@@ -54,8 +54,8 @@ test("should bump version if release already exists", async () => {
     "Incrementing Package Version 1.0.0 -> 1.0.1
 
 
-    ⬆︎ snippet.tsx
     ⬆︎ package.json
+    ⬆︎ snippet.tsx
     "@tsci/test-user.test-package@1.0.1" published!
     https://tscircuit.com/test-user/test-package
     "

--- a/tests/cli/push/push6-upload-files.test.ts
+++ b/tests/cli/push/push6-upload-files.test.ts
@@ -23,8 +23,8 @@ test("should upload files to the registry", async () => {
     "Package created
 
 
-    ⬆︎ snippet.tsx
     ⬆︎ package.json
+    ⬆︎ snippet.tsx
     "@tsci/test-user.test-package@1.0.0" published!
     https://tscircuit.com/test-user/test-package
     "


### PR DESCRIPTION
## Summary
- sort file paths when collecting package files
- update push tests' snapshots for deterministic order

## Testing
- `npm run format:check`
- `bun test tests/cli/push/push5-version-bump.test.ts tests/cli/push/push6-upload-files.test.ts`
- `bun test` *(fails: Test "clone command handles invalid package path" timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6847d8438dbc83329c5bab56dba504ce